### PR TITLE
Add documentation style guide and contributor instructions

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,21 @@
+# Agent Instructions for `docs/`
+
+These instructions apply to all files under `docs/`.
+
+## Writing style
+- Keep the friendly, action-oriented tone used in `docs/README.md`: short sentences, second-person guidance, and clear "why + how" framing.
+- Prefer lists and headings over long paragraphs; each section should be scannable.
+- Use accurate API names and consistent capitalization. Avoid inventing new terminology.
+- When adding scientific context, include a brief rationale or citation from `bibliography.bib` when possible.
+
+## Structural expectations
+- Reuse the existing section hierarchy (`##` then `###`) and keep the page order consistent with the current table of contents.
+- Place reusable assets in `_static/` and `_templates/`; do not embed large assets directly in Markdown/RST.
+- For API pages, keep entries synchronized with the Python package and use the `clean_api.py` helper when regenerating content.
+
+## Build and verification
+- After substantive edits, run `make html` from `docs/` to ensure the site builds cleanly. Use `make clean` first if cached artifacts interfere.
+- For Read the Docs compatibility, update `docs/requirements.yaml` when new optional dependencies are introduced.
+
+## Porting guidance
+- When adapting this documentation style to another project, copy the `docs/` layout, adjust branding in `conf.py` and landing pages, and preserve the tone outlined above.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,24 +1,50 @@
-# Compiling ProjectName's Documentation
+# MolSysMT Documentation Guide
 
-The docs for this project are built with [Sphinx](http://www.sphinx-doc.org/en/master/).
-To compile the docs, first ensure that Sphinx and the ReadTheDocs theme are installed.
+MolSysMT’s documentation is written with [Sphinx](https://www.sphinx-doc.org/en/master/) and organized to be easy to reuse in
+other projects that want the same tone, structure, and developer experience. This guide summarizes how to build the docs,
+explains the layout of the repository, and notes the conventions that give the site its voice.
 
+## Build the docs locally
 
-```bash
-conda install sphinx sphinx_rtd_theme 
-```
+1. Create and activate a conda environment with Sphinx and the Read the Docs theme:
+   ```bash
+   conda install sphinx sphinx_rtd_theme
+   ```
+2. From this `docs/` directory, build the HTML site:
+   ```bash
+   make html
+   ```
+3. Open `_build/html/index.html` in a browser to preview the site. The `make clean` target removes previous builds.
 
+MolSysMT ships a [Read the Docs configuration](../.readthedocs.yaml) so the online build matches local output. If you add
+optional dependencies that are needed for `autodoc`, list them in `docs/requirements.yaml`.
 
-Once installed, you can use the `Makefile` in this directory to compile static HTML pages by
-```bash
-make html
-```
+## Directory overview
 
-The compiled docs will be in the `_build` directory and can be viewed by opening `index.html` (which may itself 
-be inside a directory called `html/` depending on what version of Sphinx is installed).
+- `content/`: Source pages for user guides, tutorials, and conceptual explanations.
+- `api/` and `old_api/`: Auto-generated API references; the `clean_api.py` script keeps entries tidy.
+- `_templates/` and `_static/`: Custom theme assets and layout overrides that create the MolSysMT visual style.
+- `_bibtex/` and `bibliography.bib`: Citation management for scientific references.
+- `dev/` and `sandbox/` notebooks: Experimental material used to prototype sections before promotion to `content/`.
 
+## Writing style and tone
 
-A configuration file for [Read The Docs](https://readthedocs.org/) (readthedocs.yaml) is included in the top level of the repository. To use Read the Docs to host your documentation, go to https://readthedocs.org/ and connect this repository. You may need to change your default branch to `main` under Advanced Settings for the project.
+- Prefer short, direct sentences written in the second person (“you”) that guide the reader through each action.
+- Lead with the “why” before the “how” when introducing new concepts, and follow with minimal, reproducible code examples.
+- Use Markdown-style lists and headings to keep pages scannable; avoid long blocks of text.
+- Keep terminology consistent with the API (function and class names should match exactly, including capitalization).
+- When referencing scientific context, include brief rationale or citations from `bibliography.bib` where appropriate.
 
-If you would like to use Read The Docs with `autodoc` (included automatically) and your package has dependencies, you will need to include those dependencies in your documentation yaml file (`docs/requirements.yaml`).
+## Reusing this structure in another project
 
+To export MolSysMT’s documentation style to a new codebase:
+
+1. Copy the `docs/` directory as a starting point, including `_templates/`, `_static/`, and the `Makefile`.
+2. Replace MolSysMT-specific names in `conf.py`, `index.ipynb`, and `content/` landing pages with the new project’s branding.
+3. Update `api/` generation scripts to point to the new Python package while preserving the existing section order and headings.
+4. Keep the writing conventions above so new sections feel consistent, and use the same heading hierarchy (`##`, then `###`).
+5. Validate the migrated docs locally with `make html` and, if using Read the Docs, connect the repository with the provided
+   `.readthedocs.yaml` template as a baseline.
+
+By keeping these guidelines in mind, contributors can extend MolSysMT’s documentation—or replicate it elsewhere—without losing
+the clear, welcoming tone readers expect.


### PR DESCRIPTION
## Summary
- rewrite docs/README.md with reusable documentation build steps, structure overview, and tone guidelines
- add docs/AGENTS.md to outline writing conventions and verification steps for doc contributors

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920d4ee45d883269b79b978a63525db)